### PR TITLE
README updates regarding the client key

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ services:
       - CLIENTKEY=zg84632abhf231
 ```
 
+### Escaping special characters
+
+The ADSBHub client key is full of special characters, that can be misinterpreted on multiple levels. To avoid that:
+* Wrap the environment variable assignment (the whole assignment, not just the key) in single quotation marks so that YAML parses it correctly.
+* Duplicate every `$` character. The single `$` sign is the start of a [variable substitution](https://docs.docker.com/compose/compose-file/#variable-substitution) in docker-compose. Use `$$` instead.
+
+If your client key was `abc$123$$$ABC`, your `docker-compose.yml` should look like this:
+```yaml
+environment:
+  - 'CLIENTKEY=abc$$123$$$$$$ABC'
+```
+
 ## Up-and-Running with Docker Compose, including `mikenye/readsb`
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ docker run \
  --name adsbhub \
  -e TZ="YOURTIMEZONE" \
  -e SBSHOST=YOURSBSHOST \
- -e CLIENTKEY=YOURSHARECODE \
+ -e CLIENTKEY=YOURCLIENTKEY \
  mikenye/adsbhub
 ```
 
-You should obviously replace `YOURSBSHOST`, and `YOURSHARECODE` with appropriate values.
+You should obviously replace `YOURSBSHOST`, and `YOURCLIENTKEY` with appropriate values.
 
 For example:
 
@@ -60,7 +60,7 @@ docker run \
  -e SBSHOST=readsb \
  -e LAT=-33.33333 \
  -e LONG=111.11111 \
- -e SHARECODE=zg84632abhf231 \
+ -e CLIENTKEY=zg84632abhf231 \
  mikenye/adsbhub
 ```
 
@@ -78,7 +78,7 @@ services:
     environment:
       - TZ=Australia/Perth
       - SBSHOST=readsb
-      - SHARECODE=zg84632abhf231
+      - CLIENTKEY=zg84632abhf231
 ```
 
 ## Up-and-Running with Docker Compose, including `mikenye/readsb`
@@ -124,7 +124,7 @@ services:
     environment:
       - TZ=Australia/Perth
       - SBSHOST=readsb
-      - SHARECODE=zg84632abhf231
+      - CLIENTKEY=zg84632abhf231
     networks:
       - adsbnet
 ```


### PR DESCRIPTION
Some of the examples in the README were using the `SHARECODE` environment variable to pass the client key to the feeder script but `adsbhub.sh` expects it to be in `CLIENTKEY`.

It can be tricky to properly escape the special characters in the client key. Added a how-to.